### PR TITLE
Add default case in priority selection to handle invalid inputs

### DIFF
--- a/src/argouml-app/src/org/argouml/cognitive/ui/AddToDoItemDialog.java
+++ b/src/argouml-app/src/org/argouml/cognitive/ui/AddToDoItemDialog.java
@@ -175,15 +175,18 @@ public class AddToDoItemDialog extends ArgoDialog {
         String headline = headLineTextField.getText();
         int priority = ToDoItem.HIGH_PRIORITY;
         switch (priorityComboBox.getSelectedIndex()) {
-	case 0:
-	    priority = ToDoItem.HIGH_PRIORITY;
-	    break;
-	case 1:
-	    priority = ToDoItem.MED_PRIORITY;
-	    break;
-	case 2:
-	    priority = ToDoItem.LOW_PRIORITY;
-	    break;
+            case 0:
+                priority = ToDoItem.HIGH_PRIORITY;
+                break;
+            case 1:
+                priority = ToDoItem.MED_PRIORITY;
+                break;
+            case 2:
+                priority = ToDoItem.LOW_PRIORITY;
+                break;
+            default:
+                priority = ToDoItem.LOW_PRIORITY; // default to LOW_PRIORITY if index is invalid
+                break;
         }
         String desc = descriptionTextArea.getText();
         String moreInfoURL = moreinfoTextField.getText();


### PR DESCRIPTION
This PR adds a default case to the switch statement handling priority selection from the priorityComboBox. It ensures that any invalid index defaults to LOW_PRIORITY, preventing undefined behavior. Resolves issue #14.
