### PR TITLE
Refactor ToDoByType.java to Remove Duplicate Code in toDoItemsChanged and toDoItemsAdded

### DIFF
--- a/src/argouml-app/src/org/argouml/cognitive/ui/ToDoByType.java
+++ b/src/argouml-app/src/org/argouml/cognitive/ui/ToDoByType.java
@@ -72,75 +72,54 @@ public class ToDoByType extends ToDoPerspective
     /*
      * @see org.argouml.cognitive.ToDoListListener#toDoItemsChanged(org.argouml.cognitive.ToDoListEvent)
      */
-    public void toDoItemsChanged(ToDoListEvent tde) {
-        LOG.log(Level.FINE, "toDoItemsChanged");
-        List<ToDoItem> items = tde.getToDoItemList();
-	Object[] path = new Object[2];
-	path[0] = Designer.theDesigner().getToDoList();
+	private void processToDoItems(ToDoListEvent tde, String logMessage, boolean isChanged) {
+		LOG.log(Level.FINE, "toDoItemsChanged");
+		List<ToDoItem> items = tde.getToDoItemList();
+		Object[] path = new Object[2];
+		path[0] = Designer.theDesigner().getToDoList();
 
-        for (KnowledgeTypeNode ktn : KnowledgeTypeNode.getTypeList()) {
-	    String kt = ktn.getName();
-	    path[1] = ktn;
-	    int nMatchingItems = 0;
-            for (ToDoItem item : items) {
-		if (!item.containsKnowledgeType(kt)) {
-                    continue;
-                }
-		nMatchingItems++;
-	    }
-	    if (nMatchingItems == 0) {
-                continue;
-            }
-	    int[] childIndices = new int[nMatchingItems];
-	    Object[] children = new Object[nMatchingItems];
-	    nMatchingItems = 0;
-            for (ToDoItem item : items) {
-		if (!item.containsKnowledgeType(kt)) {
-                    continue;
-                }
-		childIndices[nMatchingItems] = getIndexOfChild(ktn, item);
-		children[nMatchingItems] = item;
-		nMatchingItems++;
-	    }
-	    fireTreeNodesChanged(this, path, childIndices, children);
+		for (KnowledgeTypeNode ktn : KnowledgeTypeNode.getTypeList()) {
+			String kt = ktn.getName();
+			path[1] = ktn;
+			int nMatchingItems = 0;
+			for (ToDoItem item : items) {
+				if (!item.containsKnowledgeType(kt)) {
+					continue;
+				}
+				nMatchingItems++;
+			}
+			if (nMatchingItems == 0) {
+				continue;
+			}
+			int[] childIndices = new int[nMatchingItems];
+			Object[] children = new Object[nMatchingItems];
+			nMatchingItems = 0;
+			for (ToDoItem item : items) {
+				if (!item.containsKnowledgeType(kt)) {
+					continue;
+				}
+				childIndices[nMatchingItems] = getIndexOfChild(ktn, item);
+				children[nMatchingItems] = item;
+				nMatchingItems++;
+			}
+			if (isChanged) {
+				fireTreeNodesChanged(this, path, childIndices, children);
+			} else {
+				fireTreeNodesInserted(this, path, childIndices, children);
+			}
+		}
 	}
+
+    public void toDoItemsChanged(ToDoListEvent tde) {
+		processToDoItems(tde, "toDoItemsChanged", true);
+
     }
 
     /*
      * @see org.argouml.cognitive.ToDoListListener#toDoItemsAdded(org.argouml.cognitive.ToDoListEvent)
      */
     public void toDoItemsAdded(ToDoListEvent tde) {
-        LOG.log(Level.FINE, "toDoItemAdded");
-        List<ToDoItem> items = tde.getToDoItemList();
-	Object[] path = new Object[2];
-	path[0] = Designer.theDesigner().getToDoList();
-
-        for (KnowledgeTypeNode ktn : KnowledgeTypeNode.getTypeList()) {
-	    String kt = ktn.getName();
-	    path[1] = ktn;
-	    int nMatchingItems = 0;
-            for (ToDoItem item : items) {
-		if (!item.containsKnowledgeType(kt)) {
-                    continue;
-                }
-		nMatchingItems++;
-	    }
-	    if (nMatchingItems == 0) {
-                continue;
-            }
-	    int[] childIndices = new int[nMatchingItems];
-	    Object[] children = new Object[nMatchingItems];
-	    nMatchingItems = 0;
-            for (ToDoItem item : items) {
-		if (!item.containsKnowledgeType(kt)) {
-                    continue;
-                }
-		childIndices[nMatchingItems] = getIndexOfChild(ktn, item);
-		children[nMatchingItems] = item;
-		nMatchingItems++;
-	    }
-	    fireTreeNodesInserted(this, path, childIndices, children);
-	}
+		processToDoItems(tde, "toDoItemsAdded", false);
     }
 
     /*


### PR DESCRIPTION
Refactored the ToDoByType class to eliminate code duplication in the toDoItemsChanged and toDoItemsAdded methods. Both methods contained nearly identical logic for processing ToDoListEvent data, resulting in redundancy and making future maintenance more challenging.

- Introduced a helper method, processToDoItems, that encapsulates the common logic previously duplicated across toDoItemsChanged and toDoItemsAdded.
- Updated toDoItemsChanged and toDoItemsAdded to call processToDoItems with appropriate parameters, reducing the codebase size and improving readability.
- Reduced Redundancy and enhanced code quality 