### PR TITLE
Fix security vulnerability reported by OWASP serializer-2.7.2.jar, xalan-2.7.2.jar and batik-css-1.14.jar 

### DIFF
--- a/src/argouml-app/pom.xml
+++ b/src/argouml-app/pom.xml
@@ -43,7 +43,7 @@
     <dependency>
       <groupId>org.apache.xmlgraphics</groupId>
       <artifactId>batik-dom</artifactId>
-      <version>1.14</version>
+      <version>1.18</version>
       <scope>compile</scope>
     </dependency>
 


### PR DESCRIPTION
Fixing the security vulnerability detected OWASP tool.
------

Identified Security Issues addressed in this PR
-------
serializer-2.7.2.jar, xalan-2.7.2.jar and batik-css-1.14.jar 
CVE-2022-40146, CVE-2022-38648, CVE-2022-38398, CVE-2022-42890, CVE-2022-41704, CVE-2022-34169
Severity: HIGH

Analysis and fix:
-----
Use mvn  dependency:tree to identify the dependency of the jar download. Research the suggested solution for addressing the vulnerability. For this scenario there are higher version with a fix provided by the vendor, it is recommended to upgrade the version jar for a solution.
Upgrade the version through pom.xml file which downloads appropriate jar during build process.

Build Results (after the fix):
-------
mvn dependency:tree :: PASS
<img width="861" alt="image" src="https://github.com/user-attachments/assets/d5a1ab63-4b29-49d1-9d29-8e065dd3f3a2">

mvn clean install :: PASS
<img width="926" alt="image" src="https://github.com/user-attachments/assets/ed40107c-d924-4045-a968-337bdaa3ccdd">

mvn clean dependency-check:aggregate :: PASS
<img width="956" alt="image" src="https://github.com/user-attachments/assets/13e64b33-3e0d-460e-80b4-f8a7f20be3f5">
