### PR TITLE
Add defensive copy for PropertyChangeEvent in DelayedChangeNotify

### DIFF
--- a/src/argouml-app/src/org/argouml/kernel/DelayedChangeNotify.java
+++ b/src/argouml-app/src/org/argouml/kernel/DelayedChangeNotify.java
@@ -55,14 +55,18 @@ public class DelayedChangeNotify implements Runnable {
      * @param p the event
      */
     public DelayedChangeNotify(DelayedVChangeListener l,
-			       PropertyChangeEvent p) {
-	listener = l;
-	pce = p;
+                               PropertyChangeEvent p) {
+        listener = l;
+        // Create a defensive copy of the PropertyChangeEvent
+        pce = new PropertyChangeEvent(p.getSource(), p.getPropertyName(),
+                p.getOldValue(), p.getNewValue());
     }
 
     /*
      * @see java.lang.Runnable#run()
      */
-    public void run() { listener.delayedVetoableChange(pce); }
+    public void run() {
+        listener.delayedVetoableChange(pce);
+    }
 
 } /* end class DelayedChangeNotify */


### PR DESCRIPTION
### Description:
This PR addresses a medium-priority vulnerability in the `DelayedChangeNotify` class where the internal state could be exposed by storing an externally mutable object (`PropertyChangeEvent`) directly. 

**Changes:**
- Added a defensive copy of the `PropertyChangeEvent` object in the constructor to prevent unintended external modifications.
- Improved encapsulation and security of the class.

**Benefits:**
- Ensures the internal state of the class is protected from external alterations.
- Mitigates risks of malicious exploitation by maintaining independent object state.

**Priority:** Medium  
**Severity:** Malicious Code Vulnerability  

### Testing:
- Verified that the functionality of `DelayedChangeNotify` remains unaffected with defensive copying.
- Confirmed that external changes to the original `PropertyChangeEvent` object do not impact the internal state of the class.