### PR TITLE
Fix internal representation exposure vulnerability in DelayedChangeNotify

### DIFF
--- a/src/argouml-app/src/org/argouml/cognitive/ui/WizStepChoice.java
+++ b/src/argouml-app/src/org/argouml/cognitive/ui/WizStepChoice.java
@@ -63,140 +63,114 @@ import org.argouml.swingext.SpacerPanel;
  */
 
 public class WizStepChoice extends WizStep {
-    private JTextArea instructions = new JTextArea();
-    private List<String> choices = new ArrayList<String>();
-    private int selectedIndex = -1;
+	private JTextArea instructions = new JTextArea();
+	private List<String> choices = new ArrayList<String>();
+	private int selectedIndex = -1;
 
+	/**
+	 * The constructor.
+	 *
+	 * @param w the wizard
+	 * @param instr the instructions
+	 * @param ch the choices
+	 */
+	public WizStepChoice(Wizard w, String instr, List<String> ch) {
+		// Store a defensive copy of the input list
+		this.choices = new ArrayList<>(ch);
 
-    /**
-     * The constructor.
-     *
-     * @param w the wizard
-     * @param instr the instructions
-     * @param ch the choices
-     */
-    public WizStepChoice(Wizard w, String instr, List<String> ch) {
-	// store wizard?
-	choices = ch;
+		instructions.setText(instr);
+		instructions.setWrapStyleWord(true);
+		instructions.setEditable(false);
+		instructions.setBorder(null);
+		instructions.setBackground(getMainPanel().getBackground());
 
-	instructions.setText(instr);
-	instructions.setWrapStyleWord(true);
-	instructions.setEditable(false);
-	instructions.setBorder(null);
-	instructions.setBackground(getMainPanel().getBackground());
+		getMainPanel().setBorder(new EtchedBorder());
 
-	getMainPanel().setBorder(new EtchedBorder());
+		GridBagLayout gb = new GridBagLayout();
+		getMainPanel().setLayout(gb);
 
-	GridBagLayout gb = new GridBagLayout();
-	getMainPanel().setLayout(gb);
+		GridBagConstraints c = new GridBagConstraints();
+		c.ipadx = 3;
+		c.ipady = 3;
+		c.weightx = 0.0;
+		c.weighty = 0.0;
+		c.anchor = GridBagConstraints.EAST;
 
-	GridBagConstraints c = new GridBagConstraints();
-	c.ipadx = 3; c.ipady = 3;
-	c.weightx = 0.0; c.weighty = 0.0;
-	c.anchor = GridBagConstraints.EAST;
+		JLabel image = new JLabel("");
+		image.setIcon(getWizardIcon());
+		image.setBorder(null);
 
-	JLabel image = new JLabel("");
-	//image.setMargin(new Insets(0, 0, 0, 0));
-	image.setIcon(getWizardIcon());
-	image.setBorder(null);
+		LayoutHelper.addComponent(getMainPanel(), image, gb, c, 0, 0, GridBagConstraints.REMAINDER, 1, 1.0, GridBagConstraints.NORTH);
 
-	LayoutHelper.addComponent(getMainPanel(), image, gb, c, 0, 0, GridBagConstraints.REMAINDER, 1, 1.0, GridBagConstraints.NORTH);
+		// Use LayoutHelper to add instructions
+		LayoutHelper.addComponent(getMainPanel(), instructions, gb, c, 2, 0, 3, 1, 1.0, GridBagConstraints.HORIZONTAL);
 
-	// Use LayoutHelper to add instructions
-	LayoutHelper.addComponent(getMainPanel(), instructions, gb, c, 2, 0, 3, 1, 1.0, GridBagConstraints.HORIZONTAL);
+		// Use LayoutHelper to add spacer
+		SpacerPanel spacer = new SpacerPanel();
+		LayoutHelper.addComponent(getMainPanel(), spacer, gb, c, 1, 1, 1, 1, 0.0, GridBagConstraints.NONE);
 
-	// Use LayoutHelper to add spacer
-	SpacerPanel spacer = new SpacerPanel();
-	LayoutHelper.addComponent(getMainPanel(), spacer, gb, c, 1, 1, 1, 1, 0.0, GridBagConstraints.NONE);
+		c.gridx = 2;
+		c.weightx = 1.0;
+		c.anchor = GridBagConstraints.WEST;
+		c.gridwidth = 1;
+		int size = this.choices.size();
+		for (int i = 0; i < size; i++) {
+			c.gridy = 2 + i;
+			String s = this.choices.get(i);
+			JRadioButton rb = new JRadioButton(s);
+			rb.setActionCommand(s);
+			rb.addActionListener(this);
+			gb.setConstraints(rb, c);
+			getMainPanel().add(rb);
+		}
 
-//	c.gridx = 0;
-//	c.gridheight = GridBagConstraints.REMAINDER;
-//	c.gridy = 0;
-//	c.anchor = GridBagConstraints.NORTH;
-//	gb.setConstraints(image, c);
-//	getMainPanel().add(image);
-//
-//	c.weightx = 1.0;
-//	c.gridx = 2;
-//	c.gridheight = 1;
-//	c.gridwidth = 3;
-//	c.gridy = 0;
-//	c.fill = GridBagConstraints.HORIZONTAL;
-//	gb.setConstraints(instructions, c);
-//	getMainPanel().add(instructions);
-//
-//	c.gridx = 1;
-//	c.gridy = 1;
-//	c.weightx = 0.0;
-//	c.gridwidth = 1;
-//	c.fill = GridBagConstraints.NONE;
-//	SpacerPanel spacer = new SpacerPanel();
-//	gb.setConstraints(spacer, c);
-//	getMainPanel().add(spacer);
-
-	c.gridx = 2;
-	c.weightx = 1.0;
-	c.anchor = GridBagConstraints.WEST;
-	c.gridwidth = 1;
-	int size = ch.size();
-	for (int i = 0; i < size; i++) {
-	    c.gridy = 2 + i;
-	    String s = ch.get(i);
-	    JRadioButton rb = new JRadioButton(s);
-	    rb.setActionCommand(s);
-	    rb.addActionListener(this);
-	    gb.setConstraints(rb, c);
-	    getMainPanel().add(rb);
+		c.gridx = 1;
+		c.gridy = 3 + this.choices.size();
+		c.weightx = 0.0;
+		c.gridwidth = 1;
+		c.fill = GridBagConstraints.NONE;
+		SpacerPanel spacer2 = new SpacerPanel();
+		gb.setConstraints(spacer2, c);
+		getMainPanel().add(spacer2);
 	}
 
-	c.gridx = 1;
-	c.gridy = 3 + ch.size();
-	c.weightx = 0.0;
-	c.gridwidth = 1;
-	c.fill = GridBagConstraints.NONE;
-	SpacerPanel spacer2 = new SpacerPanel();
-	gb.setConstraints(spacer2, c);
-	getMainPanel().add(spacer2);
-
-    }
-
-    /**
-     * @return the index of the selected item
-     */
-    public int getSelectedIndex() {
-        return selectedIndex;
-    }
-
-
-    /*
-     * @see java.awt.event.ActionListener#actionPerformed(java.awt.event.ActionEvent)
-     */
-    @Override
-    public void actionPerformed(ActionEvent e) {
-	super.actionPerformed(e);
-	if (e.getSource() instanceof JRadioButton) {
-	    String cmd = e.getActionCommand();
-	    if (cmd == null) {
-		selectedIndex = -1;
-		return;
-	    }
-	    int size = choices.size();
-	    for (int i = 0; i < size; i++) {
-		String s = choices.get(i);
-		if (s.equals(cmd)) {
-                    selectedIndex = i;
-                }
-	    }
-	    getWizard().doAction();
-	    enableButtons();
+	/**
+	 * @return the index of the selected item
+	 */
+	public int getSelectedIndex() {
+		return selectedIndex;
 	}
-    }
 
-    /**
-     * The UID.
-     */
-    private static final long serialVersionUID = 8055896491830976354L;
-} 
+	/*
+	 * @see java.awt.event.ActionListener#actionPerformed(java.awt.event.ActionEvent)
+	 */
+	@Override
+	public void actionPerformed(ActionEvent e) {
+		super.actionPerformed(e);
+		if (e.getSource() instanceof JRadioButton) {
+			String cmd = e.getActionCommand();
+			if (cmd == null) {
+				selectedIndex = -1;
+				return;
+			}
+			int size = choices.size();
+			for (int i = 0; i < size; i++) {
+				String s = choices.get(i);
+				if (s.equals(cmd)) {
+					selectedIndex = i;
+				}
+			}
+			getWizard().doAction();
+			enableButtons();
+		}
+	}
+
+	/**
+	 * The UID.
+	 */
+	private static final long serialVersionUID = 8055896491830976354L;
+}
+
 
 
 


### PR DESCRIPTION
**Description:**

This PR resolves a vulnerability identified in the DelayedChangeNotify class, where an external mutable object (PropertyChangeEvent) was being stored directly into the internal state (pce). This exposed the class to potential security risks or unintended behavior if the mutable object was altered outside the class.

**Changes Made:**

1. Modified the DelayedChangeNotify constructor to create a defensive copy of the PropertyChangeEvent object passed as a parameter.
2. Ensured the internal representation (pce) remains immutable by using the copied instance.

Before Fix:

The constructor directly stored the PropertyChangeEvent object, exposing internal state:
`pce = p;
`

After Fix:

The constructor now creates a new PropertyChangeEvent instance to preserve immutability:
`pce = new PropertyChangeEvent(p.getSource(), p.getPropertyName(), p.getOldValue(), p.getNewValue());
`

![Screenshot from 2024-12-01 02-29-33](https://github.com/user-attachments/assets/4fe7009f-083b-4999-88ff-0d4f5b8e6162)


Benefits:

1. Protects against external modifications to the PropertyChangeEvent object.
2. Mitigates potential malicious or unintentional code vulnerabilities.
3. Improves code reliability and robustness.

Related Issues:
Fixes #
